### PR TITLE
add dyn keyword to the submodules guide

### DIFF
--- a/shaku/src/guide/submodules.rs
+++ b/shaku/src/guide/submodules.rs
@@ -38,8 +38,8 @@
 //!         components = [MyComponentImpl],
 //!         providers = [],
 //!
-//!         use AuthModule {
-//!             components = [AuthManager],
+//!         use dyn AuthModule {
+//!             components = [dyn AuthManager],
 //!             providers = []
 //!         }
 //!     }
@@ -72,7 +72,7 @@
 //! # module! {
 //! #     RootModule {
 //! #         components = [MyComponentImpl], providers = [],
-//! #         use AuthModule { components = [AuthManager], providers = [] }
+//! #         use dyn AuthModule { components = [dyn AuthManager], providers = [] }
 //! #     }
 //! # }
 //! #


### PR DESCRIPTION
error[E0782]: trait objects must include the `dyn` keyword