### PR TITLE
Update to syn 2.0

### DIFF
--- a/shaku/tests/ui/component_missing_dependency.stderr
+++ b/shaku/tests/ui/component_missing_dependency.stderr
@@ -7,7 +7,7 @@ error[E0277]: the trait bound `TestModule: HasComponent<(dyn DependencyTrait + '
 25 | |         providers = []
 26 | |     }
 27 | | }
-   | |_^ the trait `HasComponent<(dyn DependencyTrait + 'static)>` is not implemented for `TestModule`, which is required by `ComponentImpl: shaku::Component<TestModule>`
+   | |_^ the trait `HasComponent<(dyn DependencyTrait + 'static)>` is not implemented for `TestModule`
    |
    = help: the trait `HasComponent<<ComponentImpl as shaku::Component<TestModule>>::Interface>` is implemented for `TestModule`
 note: required for `ComponentImpl` to implement `shaku::Component<TestModule>`
@@ -26,7 +26,7 @@ error[E0277]: `TestModule` cannot be shared between threads safely
 23 |     TestModule {
    |     ^^^^^^^^^^ `TestModule` cannot be shared between threads safely
    |
-   = help: the trait `HasComponent<(dyn DependencyTrait + 'static)>` is not implemented for `TestModule`, which is required by `TestModule: ModuleInterface`
+   = help: the trait `HasComponent<(dyn DependencyTrait + 'static)>` is not implemented for `TestModule`
    = help: the trait `HasComponent<<ComponentImpl as shaku::Component<TestModule>>::Interface>` is implemented for `TestModule`
 note: required for `ComponentImpl` to implement `shaku::Component<TestModule>`
   --> tests/ui/component_missing_dependency.rs:14:10

--- a/shaku/tests/ui/provider_missing_component_dependency.stderr
+++ b/shaku/tests/ui/provider_missing_component_dependency.stderr
@@ -7,7 +7,7 @@ error[E0277]: the trait bound `TestModule: HasComponent<(dyn DependencyTrait + '
 25 | |         providers = [ProviderImpl]
 26 | |     }
 27 | | }
-   | |_^ the trait `HasComponent<(dyn DependencyTrait + 'static)>` is not implemented for `TestModule`, which is required by `ProviderImpl: Provider<TestModule>`
+   | |_^ the trait `HasComponent<(dyn DependencyTrait + 'static)>` is not implemented for `TestModule`
    |
    = help: the trait `Provider<M>` is implemented for `ProviderImpl`
 note: required for `ProviderImpl` to implement `Provider<TestModule>`
@@ -26,7 +26,7 @@ error[E0277]: `TestModule` cannot be shared between threads safely
 23 |     TestModule {
    |     ^^^^^^^^^^ `TestModule` cannot be shared between threads safely
    |
-   = help: the trait `HasComponent<(dyn DependencyTrait + 'static)>` is not implemented for `TestModule`, which is required by `TestModule: ModuleInterface`
+   = help: the trait `HasComponent<(dyn DependencyTrait + 'static)>` is not implemented for `TestModule`
 note: required for `ProviderImpl` to implement `Provider<TestModule>`
   --> tests/ui/provider_missing_component_dependency.rs:14:10
    |

--- a/shaku/tests/ui/provider_missing_provider_dependency.stderr
+++ b/shaku/tests/ui/provider_missing_provider_dependency.stderr
@@ -7,7 +7,7 @@ error[E0277]: the trait bound `TestModule: HasProvider<(dyn DependencyTrait + 's
 24 | |         providers = [ProviderImpl]
 25 | |     }
 26 | | }
-   | |_^ the trait `HasProvider<(dyn DependencyTrait + 'static)>` is not implemented for `TestModule`, which is required by `ProviderImpl: Provider<TestModule>`
+   | |_^ the trait `HasProvider<(dyn DependencyTrait + 'static)>` is not implemented for `TestModule`
    |
    = help: the trait `HasProvider<<ProviderImpl as Provider<TestModule>>::Interface>` is implemented for `TestModule`
 note: required for `ProviderImpl` to implement `Provider<TestModule>`
@@ -26,7 +26,7 @@ error[E0277]: `TestModule` cannot be shared between threads safely
 22 |     TestModule {
    |     ^^^^^^^^^^ `TestModule` cannot be shared between threads safely
    |
-   = help: the trait `HasProvider<(dyn DependencyTrait + 'static)>` is not implemented for `TestModule`, which is required by `TestModule: ModuleInterface`
+   = help: the trait `HasProvider<(dyn DependencyTrait + 'static)>` is not implemented for `TestModule`
    = help: the trait `HasProvider<<ProviderImpl as Provider<TestModule>>::Interface>` is implemented for `TestModule`
 note: required for `ProviderImpl` to implement `Provider<TestModule>`
   --> tests/ui/provider_missing_provider_dependency.rs:13:10

--- a/shaku_derive/Cargo.toml
+++ b/shaku_derive/Cargo.toml
@@ -13,7 +13,7 @@ proc-macro = true
 
 [dependencies]
 quote = "1.0"
-syn = { version = "1.0", features = ["extra-traits", "full"] }
+syn = { version = "2.0", features = ["extra-traits", "full"] }
 proc-macro2 = "1.0"
 
 [dev-dependencies]

--- a/shaku_derive/src/parser.rs
+++ b/shaku_derive/src/parser.rs
@@ -17,5 +17,5 @@ pub trait Parser<T: Sized> {
 
 /// Find the #[shaku(...)] attribute
 fn get_shaku_attribute(attrs: &[Attribute]) -> Option<&Attribute> {
-    attrs.iter().find(|a| a.path.is_ident(consts::ATTR_NAME))
+    attrs.iter().find(|a| a.path().is_ident(consts::ATTR_NAME))
 }

--- a/shaku_derive/src/parser/module.rs
+++ b/shaku_derive/src/parser/module.rs
@@ -22,7 +22,7 @@ impl Parse for ModuleData {
             return Err(content.error("expected `,`"));
         }
 
-        let submodules = content.parse_terminated(Submodule::parse)?;
+        let submodules = content.parse_terminated(Submodule::parse, syn::Token![,])?;
 
         Ok(ModuleData {
             metadata,
@@ -113,7 +113,7 @@ where
             keyword_token: input.parse()?,
             eq_token: input.parse()?,
             bracket_token: syn::bracketed!(content in input),
-            items: content.parse_terminated(ModuleItem::parse)?,
+            items: content.parse_terminated(ModuleItem::parse, syn::Token![,])?,
         })
     }
 }
@@ -146,7 +146,7 @@ where
 
 impl Parser<ComponentAttribute> for Attribute {
     fn parse_as(&self) -> syn::Result<ComponentAttribute> {
-        if self.path.is_ident("lazy") && self.tokens.is_empty() {
+        if self.path().is_ident("lazy") && matches!(self.meta, syn::Meta::Path(_)) {
             Ok(ComponentAttribute::Lazy)
         } else {
             Err(Error::new(self.span(), "Unknown attribute".to_string()))

--- a/shaku_derive/src/parser/property_from_field.rs
+++ b/shaku_derive/src/parser/property_from_field.rs
@@ -6,7 +6,7 @@ use syn::{Attribute, Error, Expr, Field, GenericArgument, Path, PathArguments, T
 
 fn check_for_attr(attr_name: &str, attrs: &[Attribute]) -> bool {
     attrs.iter().any(|a| {
-        a.path.is_ident(consts::ATTR_NAME)
+        a.path().is_ident(consts::ATTR_NAME)
             && a.parse_args::<Path>()
                 .map(|p| p.is_ident(attr_name))
                 .unwrap_or(false)
@@ -25,7 +25,7 @@ impl Parser<Property> for Field {
         let doc_comment = self
             .attrs
             .iter()
-            .filter(|attr| attr.path.is_ident("doc"))
+            .filter(|attr| attr.path().is_ident("doc"))
             .cloned()
             .collect();
 
@@ -47,10 +47,26 @@ impl Parser<Property> for Field {
                             if has_default {
                                 Ok(PropertyDefault::NotProvided)
                             } else {
-                                Err(Error::new(
-                                    attr.span(),
-                                    format!("Unknown attribute: 'shaku{}'", attr.tokens),
-                                ))
+                                let path = match &attr.meta {
+                                    syn::Meta::Path(p) => p,
+                                    syn::Meta::List(l) => &l.path,
+                                    syn::Meta::NameValue(nv) => &nv.path,
+                                };
+                                let attr_name =
+                                    path.get_ident().map_or(String::new(), |i| i.to_string());
+
+                                let message = match &attr.meta {
+                                    syn::Meta::Path(_) => {
+                                        format!("Unknown shaku attribute: '{attr_name}'")
+                                    }
+                                    syn::Meta::List(_) => format!(
+                                        "Unknown shaku attribute with parameters: '{attr_name}'"
+                                    ),
+                                    syn::Meta::NameValue(_) => {
+                                        format!("Unknown shaku attribute with value: '{attr_name}'")
+                                    }
+                                };
+                                Err(Error::new(attr.span(), message))
                             }
                         }
                     })


### PR DESCRIPTION
## Summary

It would be great if we could update syn to version 2.0 of the API as using syn 1.0 causes some downstream projects to have multiple versions of syn in the dependency tree at the moment. There have been some breaking API changes in syn 2.0, but nothing out of the ordinary. The only think I'm not 100% sure about is the error message for unknown shaku attributes; I can change that if needed. 

## Details

Update `parse_terminated` to include separator token parameter as required by syn 2.0 API changes. Replace Attribute field access with method calls:
- path -> path()
- tokens -> meta

Update attribute parsing to handle new Meta structure and provide better error messages based on attribute type (Path, List, NameValue).

These changes were needed to fix compilation errors after dependency update to syn 2.0.101.

Note that the compiler output changed; I updated it accordingly with `TRYBUILD=overwrite cargo test -p shaku --test shaku_ui`.