### PR TITLE
Add extended support for PhantomData

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ jobs:
           command: cargo test --no-default-features --features derive -- --skip compile_fail
   shaku-msrv:
     docker:
-      - image: rust:1.38.0
+      - image: rust:1.42.0
     steps:
       - checkout
       - remove-rust-toolchain
@@ -72,7 +72,7 @@ jobs:
       - code-check:
           check-args: "--locked"
       - test:
-          # Skip compile tests, as compiler messages are different in 1.38.0.
+          # Skip compile tests, as compiler messages are different in 1.42.0.
           test-args: "--locked -- --skip compile_fail"
 workflows:
   version: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2025-01-12]
+## [2026-06-30]
+### Breaking Changes
+- Minimum supported Rust version changed to 1.42.0 (from 1.38.0)
+
 ### shaku_axum 0.6.0
 #### Breaking Changes
 - Updated to axum 0.8 (thanks [@ethanhann](https://github.com/ethanhann))

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Shaku supports the latest stable release of Rust, plus the previous two versions
 at minimum (but possibly more). Changes to the minimum supported version will be
 noted in the changelog.
 
-Minimum supported version: 1.38.0
+Minimum supported version: 1.42.0
 
 ## Project Status
 The foundation of shaku's API is in place, and now the focus is to mature the

--- a/shaku/src/guide/mod.rs
+++ b/shaku/src/guide/mod.rs
@@ -128,6 +128,23 @@
 //!
 //! (note: `#[shaku(default)]` will use the `Default` trait if no value is given for the property)
 //!
+//! Components may also contain [`PhantomData`] fields. Annotate these fields with
+//! `#[shaku(phantom)]` so the derive can initialize them automatically without treating them as
+//! component parameters or dependencies.
+//!
+//! ```
+//! # use shaku::{Component, Interface};
+//! # use std::marker::PhantomData;
+//! # trait TypedLogger<T>: Interface {}
+//! # impl<T: Send + Sync + 'static> TypedLogger<T> for TypedLoggerImpl<T> {}
+//! #[derive(Component)]
+//! #[shaku(interface = TypedLogger<T>)]
+//! struct TypedLoggerImpl<T: Send + Sync + 'static> {
+//!     #[shaku(phantom)]
+//!     marker: PhantomData<T>,
+//! }
+//! ```
+//!
 //! If you don't use the derive macro, add [`HasComponent`] bounds to your module generic and inject
 //! the dependencies manually with [`HasComponent::build_component`].
 //!
@@ -471,6 +488,7 @@
 //! [submodule guide]: submodules/index.html
 //! [`Interface`]: ../trait.Interface.html
 //! [`Component`]: ../trait.Component.html
+//! [`PhantomData`]: https://doc.rust-lang.org/std/marker/struct.PhantomData.html
 //! [`Arc`]: https://doc.rust-lang.org/std/sync/struct.Arc.html
 //! [`HasComponent`]: ../trait.HasComponent.html
 //! [`HasComponent::build_component`]: ../trait.HasComponent.html#tymethod.build_component

--- a/shaku/src/guide/mod.rs
+++ b/shaku/src/guide/mod.rs
@@ -130,18 +130,20 @@
 //!
 //! Components may also contain [`PhantomData`] fields. Annotate these fields with
 //! `#[shaku(phantom)]` so the derive can initialize them automatically without treating them as
-//! component parameters or dependencies.
+//! component parameters or dependencies. If the marker only binds a type parameter and should not
+//! require that type to implement `Send + Sync`, use a function-pointer marker such as
+//! `PhantomData<fn() -> T>` instead of `PhantomData<T>`.
 //!
 //! ```
 //! # use shaku::{Component, Interface};
 //! # use std::marker::PhantomData;
 //! # trait TypedLogger<T>: Interface {}
-//! # impl<T: Send + Sync + 'static> TypedLogger<T> for TypedLoggerImpl<T> {}
+//! # impl<T: 'static> TypedLogger<T> for TypedLoggerImpl<T> {}
 //! #[derive(Component)]
 //! #[shaku(interface = TypedLogger<T>)]
-//! struct TypedLoggerImpl<T: Send + Sync + 'static> {
+//! struct TypedLoggerImpl<T: 'static> {
 //!     #[shaku(phantom)]
-//!     marker: PhantomData<T>,
+//!     marker: PhantomData<fn() -> T>,
 //! }
 //! ```
 //!

--- a/shaku/src/guide/provider.rs
+++ b/shaku/src/guide/provider.rs
@@ -138,7 +138,9 @@
 //!
 //! Providers may also contain [`PhantomData`] fields. Annotate these fields with
 //! `#[shaku(phantom)]` so the derive can initialize them automatically without treating them as
-//! dependencies.
+//! dependencies. If the marker only binds a type parameter and should not propagate auto-trait
+//! bounds from that type, use a function-pointer marker such as `PhantomData<fn() -> T>` instead of
+//! `PhantomData<T>`.
 //!
 //! ```
 //! # use shaku::Provider;
@@ -149,7 +151,7 @@
 //! #[shaku(interface = TypedRepository<T>)]
 //! struct TypedRepositoryImpl<T: 'static> {
 //!     #[shaku(phantom)]
-//!     marker: PhantomData<T>,
+//!     marker: PhantomData<fn() -> T>,
 //! }
 //! ```
 //!

--- a/shaku/src/guide/provider.rs
+++ b/shaku/src/guide/provider.rs
@@ -143,15 +143,62 @@
 //! `PhantomData<T>`.
 //!
 //! ```
-//! # use shaku::Provider;
+//! # use shaku::{Interface, Provider};
+//! # use std::fmt;
 //! # use std::marker::PhantomData;
-//! # trait TypedRepository<T> {}
-//! # impl<T: 'static> TypedRepository<T> for TypedRepositoryImpl<T> {}
+//! # use std::ops::Deref;
+//! # #[derive(Debug)]
+//! # pub struct Error;
+//! # impl fmt::Display for Error {
+//! #     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result { write!(formatter, "command failed") }
+//! # }
+//! # impl std::error::Error for Error {}
+//! # #[derive(Debug)]
+//! # struct SmartCardError;
+//! # impl fmt::Display for SmartCardError {
+//! #     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result { write!(formatter, "smartcard failed") }
+//! # }
+//! # impl std::error::Error for SmartCardError {}
+//! # impl From<SmartCardError> for Error {
+//! #     fn from(_: SmartCardError) -> Self { Error }
+//! # }
+//! # trait SmartCard: Send + Sync {
+//! #     fn run(&self, input: &[u8]) -> Result<Vec<u8>, SmartCardError>;
+//! # }
+//! pub trait RunCommand<Input, Output>: Interface
+//! where
+//!     Input: Deref<Target = [u8]>,
+//!     Output: for<'a> From<&'a [u8]>,
+//! {
+//!     fn run(&self, input: &Input) -> Result<Output, Error>;
+//! }
+//!
 //! #[derive(Provider)]
-//! #[shaku(interface = TypedRepository<T>)]
-//! struct TypedRepositoryImpl<T: 'static> {
+//! #[shaku(interface = RunCommand<Input, Output>)]
+//! pub struct RunCommandExecuter<Input, Output>
+//! where
+//!     Input: Deref<Target = [u8]> + 'static,
+//!     Output: for<'a> From<&'a [u8]> + 'static,
+//! {
 //!     #[shaku(phantom)]
-//!     marker: PhantomData<fn() -> T>,
+//!     _input: PhantomData<fn() -> Input>,
+//!     #[shaku(phantom)]
+//!     _output: PhantomData<fn() -> Output>,
+//!     #[shaku(provide)]
+//!     smartcard: Box<dyn SmartCard>,
+//! }
+//!
+//! impl<Input, Output> RunCommand<Input, Output> for RunCommandExecuter<Input, Output>
+//! where
+//!     Input: Deref<Target = [u8]> + 'static,
+//!     Output: for<'a> From<&'a [u8]> + 'static,
+//! {
+//!     fn run(&self, input: &Input) -> Result<Output, Error> {
+//!         let input: &[u8] = input;
+//!         let output = self.smartcard.run(input).map_err(Error::from)?;
+//!
+//!         Ok(Output::from(output.as_slice()))
+//!     }
 //! }
 //! ```
 //!

--- a/shaku/src/guide/provider.rs
+++ b/shaku/src/guide/provider.rs
@@ -136,6 +136,23 @@
 //! }
 //! ```
 //!
+//! Providers may also contain [`PhantomData`] fields. Annotate these fields with
+//! `#[shaku(phantom)]` so the derive can initialize them automatically without treating them as
+//! dependencies.
+//!
+//! ```
+//! # use shaku::Provider;
+//! # use std::marker::PhantomData;
+//! # trait TypedRepository<T> {}
+//! # impl<T: 'static> TypedRepository<T> for TypedRepositoryImpl<T> {}
+//! #[derive(Provider)]
+//! #[shaku(interface = TypedRepository<T>)]
+//! struct TypedRepositoryImpl<T: 'static> {
+//!     #[shaku(phantom)]
+//!     marker: PhantomData<T>,
+//! }
+//! ```
+//!
 //! ### Manually implement Provider
 //! Sometimes you have to manually implement provider when it's not as simple as constructing a new
 //! service directly from existing ones. This is the case for `DBConnection`, as it comes from a
@@ -443,6 +460,7 @@
 //! [`Interface`]: ../../trait.Interface.html
 //! [`Component`]: ../../trait.Component.html
 //! [`Provider`]: ../../trait.Provider.html
+//! [`PhantomData`]: https://doc.rust-lang.org/std/marker/struct.PhantomData.html
 //! [`Provider::provide`]: ../../trait.Provider.html#tymethod.provide
 //! [`HasProvider::provide`]: ../../trait.HasProvider.html#tymethod.provide
 //! [`with_provider_override`]: ../../struct.ModuleBuilder.html#method.with_provider_override

--- a/shaku/tests/phantom_data.rs
+++ b/shaku/tests/phantom_data.rs
@@ -1,0 +1,61 @@
+use shaku::{module, Component, HasComponent, HasProvider, Interface, Provider};
+use std::marker::PhantomData;
+
+trait ComponentTrait: Interface {
+    fn value(&self) -> usize;
+}
+
+#[derive(Component)]
+#[shaku(interface = ComponentTrait)]
+struct PhantomComponent<T: Send + Sync + 'static> {
+    #[shaku(default = 17)]
+    value: usize,
+    #[shaku(phantom)]
+    marker: PhantomData<T>,
+}
+
+impl<T: Send + Sync + 'static> ComponentTrait for PhantomComponent<T> {
+    fn value(&self) -> usize {
+        self.value
+    }
+}
+
+trait ProviderTrait {
+    fn value(&self) -> usize;
+}
+
+#[derive(Provider)]
+#[shaku(interface = ProviderTrait)]
+struct PhantomProvider<T: 'static> {
+    #[shaku(phantom)]
+    marker: PhantomData<T>,
+}
+
+impl<T: 'static> ProviderTrait for PhantomProvider<T> {
+    fn value(&self) -> usize {
+        23
+    }
+}
+
+module! {
+    TestModule {
+        components = [PhantomComponent<String>],
+        providers = [PhantomProvider<String>]
+    }
+}
+
+#[test]
+fn component_phantom_data_is_initialized() {
+    let module = TestModule::builder().build();
+    let component: &dyn ComponentTrait = module.resolve_ref();
+
+    assert_eq!(component.value(), 17);
+}
+
+#[test]
+fn provider_phantom_data_is_initialized() {
+    let module = TestModule::builder().build();
+    let provider: Box<dyn ProviderTrait> = module.provide().unwrap();
+
+    assert_eq!(provider.value(), 23);
+}

--- a/shaku/tests/phantom_data.rs
+++ b/shaku/tests/phantom_data.rs
@@ -1,5 +1,6 @@
 use shaku::{module, Component, HasComponent, HasProvider, Interface, Provider};
 use std::marker::PhantomData;
+use std::rc::Rc;
 
 trait ComponentTrait: Interface {
     fn value(&self) -> usize;
@@ -7,14 +8,14 @@ trait ComponentTrait: Interface {
 
 #[derive(Component)]
 #[shaku(interface = ComponentTrait)]
-struct PhantomComponent<T: Send + Sync + 'static> {
+struct PhantomComponent<T: 'static> {
     #[shaku(default = 17)]
     value: usize,
     #[shaku(phantom)]
-    marker: PhantomData<T>,
+    marker: PhantomData<fn() -> T>,
 }
 
-impl<T: Send + Sync + 'static> ComponentTrait for PhantomComponent<T> {
+impl<T: 'static> ComponentTrait for PhantomComponent<T> {
     fn value(&self) -> usize {
         self.value
     }
@@ -39,7 +40,7 @@ impl<T: 'static> ProviderTrait for PhantomProvider<T> {
 
 module! {
     TestModule {
-        components = [PhantomComponent<String>],
+        components = [PhantomComponent<Rc<()>>],
         providers = [PhantomProvider<String>]
     }
 }

--- a/shaku/tests/phantom_data.rs
+++ b/shaku/tests/phantom_data.rs
@@ -1,5 +1,8 @@
 use shaku::{module, Component, HasComponent, HasProvider, Interface, Provider};
+use std::error::Error as StdError;
+use std::fmt;
 use std::marker::PhantomData;
+use std::ops::Deref;
 use std::rc::Rc;
 
 trait ComponentTrait: Interface {
@@ -21,27 +24,99 @@ impl<T: 'static> ComponentTrait for PhantomComponent<T> {
     }
 }
 
-trait ProviderTrait {
-    fn value(&self) -> usize;
+#[derive(Debug)]
+struct CommandError;
+
+impl fmt::Display for CommandError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "command failed")
+    }
+}
+
+impl StdError for CommandError {}
+
+#[derive(Debug)]
+struct SmartCardError;
+
+impl fmt::Display for SmartCardError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "smartcard failed")
+    }
+}
+
+impl StdError for SmartCardError {}
+
+impl From<SmartCardError> for CommandError {
+    fn from(_: SmartCardError) -> Self {
+        Self
+    }
+}
+
+trait SmartCard: Send + Sync {
+    fn run(&self, input: &[u8]) -> Result<Vec<u8>, SmartCardError>;
 }
 
 #[derive(Provider)]
-#[shaku(interface = ProviderTrait)]
-struct PhantomProvider<T: 'static> {
-    #[shaku(phantom)]
-    marker: PhantomData<T>,
+#[shaku(interface = SmartCard)]
+struct SmartCardImpl;
+
+impl SmartCard for SmartCardImpl {
+    fn run(&self, input: &[u8]) -> Result<Vec<u8>, SmartCardError> {
+        let mut output = b"echo: ".to_vec();
+        output.extend_from_slice(input);
+        Ok(output)
+    }
 }
 
-impl<T: 'static> ProviderTrait for PhantomProvider<T> {
-    fn value(&self) -> usize {
-        23
+trait RunCommand<Input, Output>: Interface
+where
+    Input: Deref<Target = [u8]>,
+    Output: for<'a> From<&'a [u8]>,
+{
+    fn run(&self, input: &Input) -> Result<Output, CommandError>;
+}
+
+#[derive(Provider)]
+#[shaku(interface = RunCommand<Input, Output>)]
+struct RunCommandExecuter<Input, Output>
+where
+    Input: Deref<Target = [u8]> + 'static,
+    Output: for<'a> From<&'a [u8]> + 'static,
+{
+    #[shaku(phantom)]
+    _input: PhantomData<fn() -> Input>,
+    #[shaku(phantom)]
+    _output: PhantomData<fn() -> Output>,
+    #[shaku(provide)]
+    smartcard: Box<dyn SmartCard>,
+}
+
+impl<Input, Output> RunCommand<Input, Output> for RunCommandExecuter<Input, Output>
+where
+    Input: Deref<Target = [u8]> + 'static,
+    Output: for<'a> From<&'a [u8]> + 'static,
+{
+    fn run(&self, input: &Input) -> Result<Output, CommandError> {
+        let input: &[u8] = input;
+        let output = self.smartcard.run(input).map_err(CommandError::from)?;
+
+        Ok(Output::from(output.as_slice()))
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct CommandOutput(Rc<[u8]>);
+
+impl From<&[u8]> for CommandOutput {
+    fn from(value: &[u8]) -> Self {
+        Self(Rc::from(value))
     }
 }
 
 module! {
     TestModule {
         components = [PhantomComponent<Rc<()>>],
-        providers = [PhantomProvider<String>]
+        providers = [SmartCardImpl, RunCommandExecuter<Rc<[u8]>, CommandOutput>]
     }
 }
 
@@ -56,7 +131,10 @@ fn component_phantom_data_is_initialized() {
 #[test]
 fn provider_phantom_data_is_initialized() {
     let module = TestModule::builder().build();
-    let provider: Box<dyn ProviderTrait> = module.provide().unwrap();
+    let provider: Box<dyn RunCommand<Rc<[u8]>, CommandOutput>> = module.provide().unwrap();
+    let input = Rc::from(&b"ping"[..]);
 
-    assert_eq!(provider.value(), 23);
+    let output = provider.run(&input).unwrap();
+
+    assert_eq!(output, CommandOutput(Rc::from(&b"echo: ping"[..])));
 }

--- a/shaku_derive/src/consts.rs
+++ b/shaku_derive/src/consts.rs
@@ -3,4 +3,5 @@ pub const INTERFACE_ATTR_NAME: &str = "interface";
 pub const INJECT_ATTR_NAME: &str = "inject";
 pub const PROVIDE_ATTR_NAME: &str = "provide";
 pub const DEFAULT_ATTR_NAME: &str = "default";
+pub const PHANTOM_ATTR_NAME: &str = "phantom";
 pub const DEBUG_ENV_VAR: &str = "SHAKU_CODEGEN_DEBUG";

--- a/shaku_derive/src/macros/common_output.rs
+++ b/shaku_derive/src/macros/common_output.rs
@@ -7,7 +7,7 @@ pub fn create_dependency(property: &Property) -> Option<TokenStream> {
     let property_ty = &property.ty;
 
     match property.property_type {
-        PropertyType::Parameter => None,
+        PropertyType::Parameter | PropertyType::PhantomData => None,
         PropertyType::Component => Some(quote! {
             ::shaku::HasComponent<#property_ty>
         }),

--- a/shaku_derive/src/macros/component.rs
+++ b/shaku_derive/src/macros/component.rs
@@ -103,30 +103,42 @@ fn create_resolve_property(property: &Property) -> syn::Result<TokenStream> {
             property.property_name.span(),
             "Provider dependencies are not allowed in Components",
         )),
+        PropertyType::PhantomData => Ok(quote! {
+            #property_name: ::std::marker::PhantomData
+        }),
     }
 }
 
 fn create_parameters_property(property: &Property, vis: &Visibility) -> Option<TokenStream> {
-    if property.is_service() {
-        return None;
-    }
-
     let property_name = &property.property_name;
     let property_type = &property.ty;
     let doc_comment = &property.doc_comment;
 
-    Some(quote! {
-        #(#doc_comment)*
-        #vis #property_name: #property_type
-    })
+    match property.property_type {
+        PropertyType::Parameter => Some(quote! {
+            #(#doc_comment)*
+            #vis #property_name: #property_type
+        }),
+        PropertyType::PhantomData => Some(quote! {
+            #[doc(hidden)]
+            #vis #property_name: #property_type
+        }),
+        _ => None,
+    }
 }
 
 fn create_parameters_default(property: &Property, component_ident: &Ident) -> Option<TokenStream> {
-    if property.is_service() {
-        return None;
+    let property_name = &property.property_name;
+
+    if matches!(property.property_type, PropertyType::PhantomData) {
+        return Some(quote! {
+            #property_name: ::std::marker::PhantomData
+        });
     }
 
-    let property_name = &property.property_name;
+    if !property.is_parameter() {
+        return None;
+    }
 
     match &property.default {
         PropertyDefault::Provided(default_expr) => Some(quote! {

--- a/shaku_derive/src/macros/provider.rs
+++ b/shaku_derive/src/macros/provider.rs
@@ -77,5 +77,8 @@ fn create_property_assignment(property: &Property) -> syn::Result<TokenStream> {
             property.property_name.span(),
             "Parameters are not allowed in Providers",
         )),
+        PropertyType::PhantomData => Ok(quote! {
+            #property_name: ::std::marker::PhantomData
+        }),
     }
 }

--- a/shaku_derive/src/parser/property_from_field.rs
+++ b/shaku_derive/src/parser/property_from_field.rs
@@ -20,6 +20,7 @@ impl Parser<Property> for Field {
     fn parse_as(&self) -> syn::Result<Property> {
         let is_injected = check_for_attr(consts::INJECT_ATTR_NAME, &self.attrs);
         let is_provided = check_for_attr(consts::PROVIDE_ATTR_NAME, &self.attrs);
+        let is_phantom = check_for_attr(consts::PHANTOM_ATTR_NAME, &self.attrs);
         let has_default = check_for_attr(consts::DEFAULT_ATTR_NAME, &self.attrs);
 
         let property_name = self.ident.clone().ok_or_else(|| {
@@ -32,8 +33,8 @@ impl Parser<Property> for Field {
             .cloned()
             .collect();
 
-        let property_type = match (is_injected, is_provided) {
-            (false, false) => {
+        let property_type = match (is_injected, is_provided, is_phantom) {
+            (false, false, false) => {
                 let property_default = get_shaku_attribute(&self.attrs)
                     .map(|attr| match attr.parse_args::<KeyValue<Expr>>().ok() {
                         Some(inner) => {
@@ -69,12 +70,39 @@ impl Parser<Property> for Field {
                     doc_comment,
                 });
             }
-            (false, true) => PropertyType::Provided,
-            (true, false) => PropertyType::Component,
-            (true, true) => {
+            (false, false, true) => {
+                if !is_phantom_data(&self.ty) {
+                    return Err(Error::new(
+                        property_name.span(),
+                        format!(
+                            "Found non-PhantomData type annotated with #[{}({})]",
+                            consts::ATTR_NAME,
+                            consts::PHANTOM_ATTR_NAME
+                        ),
+                    ));
+                }
+
+                return Ok(Property {
+                    property_name,
+                    ty: self.ty.clone(),
+                    key_ty: None,
+                    property_type: PropertyType::PhantomData,
+                    default: PropertyDefault::NotProvided,
+                    doc_comment,
+                });
+            }
+            (false, true, false) => PropertyType::Provided,
+            (true, false, false) => PropertyType::Component,
+            (true, true, _) => {
                 return Err(Error::new(
                     property_name.span(),
                     "Cannot inject and provide the same property",
+                ))
+            }
+            _ => {
+                return Err(Error::new(
+                    property_name.span(),
+                    "Cannot combine phantom with inject or provide",
                 ))
             }
         };
@@ -143,11 +171,16 @@ impl Parser<Property> for Field {
                     doc_comment,
                 })
             }
-            PropertyType::Parameter | PropertyType::ComponentVec | PropertyType::ComponentMap => {
-                unreachable!()
-            }
+            PropertyType::Parameter
+            | PropertyType::ComponentVec
+            | PropertyType::ComponentMap
+            | PropertyType::PhantomData => unreachable!(),
         }
     }
+}
+
+fn is_phantom_data(ty: &Type) -> bool {
+    angle_bracketed_args(ty, "PhantomData").is_some()
 }
 
 fn parse_vec_arc_interface(ty: &Type) -> Option<Type> {

--- a/shaku_derive/src/structures/service.rs
+++ b/shaku_derive/src/structures/service.rs
@@ -36,6 +36,7 @@ pub enum PropertyType {
     ComponentVec,
     ComponentMap,
     Provided,
+    PhantomData,
 }
 
 /// Holds information about a service property.
@@ -52,14 +53,8 @@ pub struct Property {
 }
 
 impl Property {
-    pub fn is_service(&self) -> bool {
-        match self.property_type {
-            PropertyType::Component
-            | PropertyType::ComponentVec
-            | PropertyType::ComponentMap
-            | PropertyType::Provided => true,
-            PropertyType::Parameter => false,
-        }
+    pub fn is_parameter(&self) -> bool {
+        matches!(self.property_type, PropertyType::Parameter)
     }
 }
 

--- a/shaku_derive/tests/ui/phantom_non_phantom_data.rs
+++ b/shaku_derive/tests/ui/phantom_non_phantom_data.rs
@@ -1,0 +1,14 @@
+use shaku::{Component, Interface};
+
+trait ComponentTrait: Interface {}
+
+#[derive(Component)]
+#[shaku(interface = ComponentTrait)]
+struct ComponentImpl {
+    #[shaku(phantom)]
+    marker: String,
+}
+
+impl ComponentTrait for ComponentImpl {}
+
+fn main() {}

--- a/shaku_derive/tests/ui/phantom_non_phantom_data.stderr
+++ b/shaku_derive/tests/ui/phantom_non_phantom_data.stderr
@@ -1,0 +1,8 @@
+warning: `$WORKSPACE/target/tests/shaku_derive/.cargo/config` is deprecated in favor of `config.toml`
+  |
+  = help: if you need to support cargo 1.38 or earlier, you can symlink `config` to `config.toml`
+error: Found non-PhantomData type annotated with #[shaku(phantom)]
+ --> $DIR/phantom_non_phantom_data.rs:9:5
+  |
+9 |     marker: String,
+  |     ^^^^^^


### PR DESCRIPTION
Hello,

we’ve been using shaku for a while now, and it meets our needs perfectly. Thank you for this project.

However, we now have an increasing number of similar interfaces and implementations, so I’d like to start using generics more. Since I have to use generics type parameters in the structs, I’m using [PhantomData](https://doc.rust-lang.org/std/marker/struct.PhantomData.html) for that.

We mostly use providers, so we can’t implement them with defaults. That’s why I’ve added an extension to PhantomData so that these variables can be initialized automatically.

I think the feature is sufficiently described in the documentation included in the PR, so I won’t provide a more detailed description here.

Disclaimer: This change was generated by an AI, but I have thoroughly reviewed the code, so it should meet general standards.

I would be happy if this extension could be incorporated into the library. If there are any requested changes, I’m happy to implement them.